### PR TITLE
fix/win32-remote-paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 1.1.1 - delivery @22/12/2021
+
+- fix win32 paths added as remote keys on S3 when it should be posix
+
 ## 1.1.0 - delivery @16/12/2021
 
 - add ignore option when uploading a directory to ignore certain strings in keys to upload

--- a/lib/index.js
+++ b/lib/index.js
@@ -20,7 +20,7 @@
  */
 const { createHash } = require('crypto');
 const { createReadStream, promises: { readdir, stat: getStats } } = require('fs');
-const { resolve, join } = require('path');
+const { posix, resolve } = require('path');
 const S3 = require('aws-sdk/clients/s3');
 const { getMIMEType } = require('node-mime-types');
 const debug = require('bugbug')('s3-lambo', 'red');
@@ -291,9 +291,9 @@ const uploadDirectory = async function uploadDirectory({
 
     if (is(Array, filenames)) {
       await Promise.all(filenames.map(async (filename) => {
-        const filepath = join(dirPath, filename);
+        const filepath = posix.join(dirPath, filename);
         const fileStats = await getStats(filepath);
-        const key = join(root, filename);
+        const key = posix.join(root, filename);
         let isIgnored = false;
 
         if (exists(ignoreInKeys)) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s3-lambo",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "author": "ThousandX <hi@thousand.xyz> (https://github.com/thousandxyz)",
   "description": "AWS S3 helpers for Node.js, as fast as a Lambo",
   "bin": {},


### PR DESCRIPTION
#### What does this PR contain?

<!--
  Thank you for your Pull Request.
  Remove items that do not apply. For completed items, change [ ] to [x].
-->
Related issue: https://github.com/thousandxyz/s3-lambo/issues/5

- fix win32 paths added as remote keys on S3 when it should be posix

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**
- [ ] **dependency update**
- [ ] **documentation update**

#### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

Uploading file was not working on Windows.

#### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

No regression.

#### Release Notes

<!-- Please add a one-line description for maintainers to read in the release notes. -->
